### PR TITLE
Fixed guest account detection - issue #31

### DIFF
--- a/classes/widgets/widgetbase.php
+++ b/classes/widgets/widgetbase.php
@@ -150,7 +150,7 @@ abstract class widgetbase {
         /** @var \moodle_database $DB */ $DB;
         /** @var stdClass $USER */ $USER;
 
-        if (!$USER || !$USER->id) {
+        if (!$USER || !$USER->id || isguestuser($USER)) {
             return $this->getguestconfig();
         }
 
@@ -169,7 +169,7 @@ abstract class widgetbase {
         /** @var \moodle_database $DB */ $DB;
         /** @var stdClass $USER */ $USER;
 
-        if (!$USER || !$USER->id) {
+        if (!$USER || !$USER->id || isguestuser($USER)) {
             return $this->setguestconfig($value);
         }
 

--- a/tests/external/savewidgetconfig_test.php
+++ b/tests/external/savewidgetconfig_test.php
@@ -78,6 +78,7 @@ final class savewidgetconfig_test extends \advanced_testcase {
      */
     public function test_savewidgetconfig_guest(): void {
         $this->resetAfterTest(true);
+        $this->setGuestUser();
 
         $widget = local_accessibility_getwidgetinstancebyname('fontsize');
 

--- a/tests/userconfigs_test.php
+++ b/tests/userconfigs_test.php
@@ -72,6 +72,7 @@ final class userconfigs_test extends testcase {
      */
     public function test_guestconfig(): void {
         $this->resetAfterTest(true);
+        $this->setGuestUser();
 
         $widget = local_accessibility_getwidgetinstancebyname('fontsize');
 


### PR DESCRIPTION
Related to https://github.com/ponlawat-w/moodle-local_accessibility/issues/31
Currently the plugin saves preferences for the guest user like it would for a standard user, thus any anonymous users are able to owerwrite how public pages are displayed for everyone.
After looking at the code, it does seem like a bug, not an expected behaviour. 
The guest user preferences are supposed to only be saved temporarily in the session, but the guest account detection code is wrong as it only does the check on USER->id. 
The moodle guest account is a real existing account in database, with an actual ID, so the code treat it like any other user, and the session mechanics are never invoked.
I just fixed the checks by using the dedicated isguestuser() method.
From my tests on my side it seems to have the fixed the unwanted behaviour.